### PR TITLE
Update cache keys for easier invalidation

### DIFF
--- a/src/lib/artist.py
+++ b/src/lib/artist.py
@@ -48,7 +48,7 @@ def get_artists_by_service(service, reload = False):
 
 def get_artist(artist_id, service, reload = False):
     redis = get_conn()
-    key = 'artist:' + str(artist_id) + ':' + service
+    key = 'artist:' + service + ':' + str(artist_id)
     artist = redis.get(key)
     if artist is None or reload:
         cursor = get_cursor()
@@ -60,9 +60,9 @@ def get_artist(artist_id, service, reload = False):
         artist = deserialize_artist(artist)
     return artist
 
-def get_artist_post_count(artist_id, reload = False):
+def get_artist_post_count(artist_id, service, reload = False):
     redis = get_conn()
-    key = 'artist_post_count:' + str(artist_id)
+    key = 'artist_post_count:' + service + ':' + str(artist_id)
     count = redis.get(key)
     if count is None or reload:
         cursor = get_cursor()

--- a/src/lib/post.py
+++ b/src/lib/post.py
@@ -20,7 +20,7 @@ def get_all_post_keys(reload = False):
 
 def get_post(post_id, artist_id, service, reload = False):
     redis = get_conn()
-    key = 'post:' + str(post_id) + ':' + str(artist_id) + ':' + service
+    key = 'post:' + service + ':' + str(artist_id) + ':' + str(post_id)
     post = redis.get(key)
     if post is None or reload:
         cursor = get_cursor()
@@ -34,7 +34,7 @@ def get_post(post_id, artist_id, service, reload = False):
 
 def get_all_posts_by_artist(artist_id, service, reload = False):
     redis = get_conn()
-    key = 'posts_by_artist:' + str(artist_id)
+    key = 'posts_by_artist:' + service + ':' + str(artist_id)
     posts = redis.get(key)
     if posts is None or reload:
         cursor = get_cursor()
@@ -48,7 +48,7 @@ def get_all_posts_by_artist(artist_id, service, reload = False):
 
 def get_artist_posts(artist_id, service, offset, limit, sort = 'id', reload = False):
     redis = get_conn()
-    key = 'artist_posts_offset:' + str(artist_id) + ':' + str(offset)
+    key = 'artist_posts_offset:' + service + ':' + str(artist_id) + ':' + str(offset)
     posts = redis.get(key)
     if posts is None or reload:
         cursor = get_cursor()
@@ -60,23 +60,9 @@ def get_artist_posts(artist_id, service, offset, limit, sort = 'id', reload = Fa
         posts = deserialize_posts(posts)
     return posts
 
-def get_artist_posts_with_search(artist_id, service, search, offset, reload = False):
-    redis = get_conn()
-    key = 'artist_posts_offset:' + str(artist_id) + ':' + str(offset)
-    posts = redis.get(key)
-    if posts is None or reload:
-        cursor = get_cursor()
-        query = 'SELECT * FROM posts WHERE \"user\" = %s AND service = %s'
-        cursor.execute(query, (artist_id, service,))
-        posts = cursor.fetchall()
-        redis.set(key, serialize_post(posts), ex = 600)
-    else:
-        posts = deserialize_post(posts)
-    return posts
-
 def is_post_flagged(post_id, artist_id, service, reload = False):
     redis = get_conn()
-    key = 'is_post_flagged:' + str(post_id) + ':' + str(artist_id) + ':' + service
+    key = 'is_post_flagged:' + service + ':' + str(artist_id) + ':' + str(post_id)
     flagged = redis.get(key)
     if flagged is None or reload:
         cursor = get_cursor()
@@ -90,7 +76,7 @@ def is_post_flagged(post_id, artist_id, service, reload = False):
 
 def get_next_post_id(post_id, artist_id, service, reload = False):
     redis = get_conn()
-    key = 'next_post:' + str(post_id) + ':' + str(artist_id) + ':' + service
+    key = 'next_post:' + service + ':' + str(artist_id) + ':' + str(post_id)
     next_post = redis.get(key)
     if next_post is None or reload:
         cursor = get_cursor()
@@ -129,7 +115,7 @@ def get_next_post_id(post_id, artist_id, service, reload = False):
 
 def get_previous_post_id(post_id, artist_id, service, reload = False):
     redis = get_conn()
-    key = 'previous_post:' + str(post_id) + ':' + str(artist_id) + ':' + service
+    key = 'previous_post:' + service + ':' + str(artist_id) + ':' + str(post_id)
     prev_post = redis.get(key)
     if prev_post is None or reload:
         cursor = get_cursor()

--- a/src/pages/artists.py
+++ b/src/pages/artists.py
@@ -164,5 +164,5 @@ def do_artist_post_search(id, service, search, o, limit):
 
 def get_artist_post_page(artist_id, service, offset, limit):
     posts = get_artist_posts(artist_id, service, offset, limit, 'published desc')
-    total_count = get_artist_post_count(artist_id)
+    total_count = get_artist_post_count(artist_id, service)
     return (posts, total_count)


### PR DESCRIPTION
From now on we should build cache keys in increasing specificity: service > artist_id > post_id
Makes it easier to do wildcard invalidations with redis (`some_key:service:artist_id:*` instead of having to enumerate all posts like you'd have to do if it went `some_key:artist_id:{post_id}:service`)