### PR TITLE
ci(webpack): recursive template configs

### DIFF
--- a/client/configs/build-templates.js
+++ b/client/configs/build-templates.js
@@ -3,39 +3,92 @@ const fse = require("fs-extra");
 const HTMLWebpackPlugin = require("html-webpack-plugin");
 
 /**
- * Builds an array of HTML webpack plugins from the provided folder.
- * @param {string} basePath An absolute path to the folder containing template files.
- * @param {string} projectPath An absolute path to the folder containing project files.
- * @param {HTMLWebpackPlugin.Options} options HTMLWebpackPlugin options.
+ * @typedef BuildOptions
+ * @property {string} fileExtension
+ * @property {string} outputPrefix
+ * @property {HTMLWebpackPlugin.Options} pluginOptions Webpack plugin options.
  */
-function buildHTMLWebpackPlugins(basePath, projectPath, options) {
+
+/** */
+class TemplateFile {
+  /**
+   * @param {fse.Dirent} dirent 
+   * @param {string} path Absolute path to the file.
+   */
+  constructor(dirent, path) {
+    this.dirent = dirent;
+    this.path = path;
+  }
+}
+
+/**
+ * Builds an array of HTML webpack plugins from the provided folder.
+ * @param {string} basePath Absolute path to the template folder.
+ * @param {BuildOptions} options Build optons.
+ */
+ function buildHTMLWebpackPluginsRecursive(basePath, options) {
   /**
    * @type {HTMLWebpackPlugin[]}
    */
   const plugins = [];
-  const files = fse.readdirSync(basePath, { withFileTypes: true });
+  const files = walkFolder(basePath);
 
   files.forEach(( file ) => {
-    const isHTML = file.isFile() && file.name.endsWith(".html");
-    
-    if (isHTML) {
-      const templatePath = path.join(basePath, file.name);
-      const outputBase = path.relative(projectPath, basePath);
-      const outputPath = path.join(outputBase, file.name);
+    const isTemplateFile = file.dirent.isFile() && file.path.endsWith(`${options.fileExtension}`);
+
+    if (isTemplateFile) {
+      const outputBase = path.relative(basePath, file.path);
+      const outputPath = path.join(path.basename(basePath), outputBase);
 
       const webpackPlugin = new HTMLWebpackPlugin({
-        ...options,
-        template: templatePath,
+        ...options.pluginOptions,
+        template: file.path,
         filename: outputPath,
       });
-
+  
       plugins.push(webpackPlugin);
     }
+
   });
 
   return plugins;
 }
 
+/**
+ * @param {string} folderPath Absolute path to the folder.
+ * @param {TemplateFile[]} files
+ */
+function walkFolder(folderPath, files = [], currentCount = 0) {
+  const nestedLimit = 1000;
+  const folderContents = fse.readdirSync(folderPath, {withFileTypes: true});
+
+  folderContents.forEach((entry) => {
+    const file = entry.isFile() && entry;
+    const folder = entry.isDirectory() && entry;
+
+    if (file) {
+      const filePath = path.join(folderPath, file.name);
+      files.push(new TemplateFile(file, filePath));
+      return;
+    }
+
+    if (folder) {
+      currentCount++;
+
+      if (currentCount > nestedLimit) {
+        throw new Error(`The folder at "${folderPath}" contains more than ${nestedLimit} folders.`);
+      }
+
+      const newFolderPath = path.join(folderPath, folder.name);
+
+      return walkFolder(newFolderPath, files, currentCount);
+    }
+
+  });
+
+  return files;
+}
+
 module.exports = {
-  buildHTMLWebpackPlugins
+  buildHTMLWebpackPluginsRecursive
 }

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,18 +1,18 @@
 const path = require("path");
 const { DefinePlugin } = require("webpack");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const { buildHTMLWebpackPlugins } = require("./configs/build-templates");
+const { buildHTMLWebpackPluginsRecursive } = require("./configs/build-templates");
 const { kemonoSite, nodeEnv } = require("./configs/vars");
 
 const projectPath = path.resolve(__dirname, "src");
 const pagesPath = path.join(projectPath, "pages");
-const componentsPath = path.resolve(projectPath, "pages", "components");
-const pluginOptions = {
-  inject: false,
-  minify: false,
-};
-const pagePlugins = buildHTMLWebpackPlugins(pagesPath, projectPath, pluginOptions);
-const componentPlugins = buildHTMLWebpackPlugins(componentsPath, projectPath, pluginOptions);
+const pagePlugins = buildHTMLWebpackPluginsRecursive(pagesPath, {
+  fileExtension: "html",
+  pluginOptions: {
+    inject: false,
+    minify: false,
+  }
+});
 
 /**
  * @type import("webpack").Configuration
@@ -23,7 +23,6 @@ const webpackConfig = {
   },
   plugins: [
     ...pagePlugins,
-    ...componentPlugins,
     new DefinePlugin({
       "BUNDLER_ENV_KEMONO_SITE": JSON.stringify(kemonoSite),
       "BUNDLER_ENV_NODE_ENV": JSON.stringify(nodeEnv),


### PR DESCRIPTION
Allows to place templates in arbitrary folder structure,
instead of only 2 folders.