### PR TITLE
Fix sidebar icon issues

### DIFF
--- a/client/src/pages/components/navigation/sidebar.scss
+++ b/client/src/pages/components/navigation/sidebar.scss
@@ -2,7 +2,7 @@
 
 .global-sidebar {
   display: flex;
-  width: 12rem;
+  width: 13rem;
   min-width: 160px;
   flex-direction: column;
   overflow: auto;
@@ -82,9 +82,9 @@
       }
 
       &-icon {
-        width: 24px;
-        height: 24px;
-        margin-right: 5px;
+        width: 20px;
+        height: 20px;
+        margin-right: 7px;
       }
 
       &.clickable-header {
@@ -109,10 +109,7 @@
       &:not(.header):focus, &.clickable-header:focus {
         background: rgb(255 255 255 / 10%);
       }
-      &.clickable-header {
-          padding-top: 0;
-      }
-        
+
       &.donate {
         color: hsl(3, 100%, 70%);
       }

--- a/client/src/pages/components/shell.js
+++ b/client/src/pages/components/shell.js
@@ -82,6 +82,7 @@ export function initShell(sidebar) {
     const newHeader = document.createElement('div');
     newHeader.className = 'global-sidebar-entry-item header';
     newHeader.innerText = 'Account';
+    newHeader.prepend(accountHeader.firstElementChild);
     accountHeader.parentElement.replaceChild(newHeader, accountHeader);
   }
   // questionable? close sidebar on tap of an item,


### PR DESCRIPTION
Fixes:
- widen sidebar to accommodate the icons, fixing home button text clipping
- fix home button being offcenter vertically
- fix Account header not having an icon if you weren't logged in
- made icons smaller to match text a bit better